### PR TITLE
Decode collected email addresses

### DIFF
--- a/dianyou.el
+++ b/dianyou.el
@@ -302,7 +302,7 @@ Final result is inserted into `kill-ring' and returned."
 ;;;###autoload
 (defun dianyou-get-all-email-addresses ()
   "Get all email addresses in received mails and update history."
-  (let* ((all-addresses (dianyou-all-email-address))
+  (let* ((all-addresses (mapcar 'rfc2047-decode-string (dianyou-all-email-address)))
          (cands (cond
                  ((and dianyou-email-address-history all-addresses)
                   (append dianyou-email-address-history


### PR DESCRIPTION
Some email addresses are encoded in the headers, so this shows and inserts the actual values instead of the `=?iso-8859-1?Q?...` raw values.